### PR TITLE
switch to bionic and derive package name and version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # Made by Dirk Eddelbuettel in August 2018 and released under GPL (>=2)
 
 os: linux
-dist: trusty
+dist: bionic
 sudo: required
 services: docker
 
@@ -13,6 +13,9 @@ env:
       DOCKER_CNTR="rcpp/run"
       R_BLD_OPTS="--no-build-vignettes --no-manual"
       R_CHK_OPTS="--no-vignettes --no-manual"
+      PKG_NAME=$(awk '/Package:/ {print $2}' DESCRIPTION)
+      PKG_VER=$(awk '/Version:/ {print $2}' DESCRIPTION)
+      PKG_TGZ="${PKG_NAME}_${PKG_VER}.tar.gz"
 
 before_install:
   - docker pull ${DOCKER_CNTR}
@@ -22,7 +25,7 @@ install:
   - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD build ${R_BLD_OPTS} .
 
 script:
-  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_CHK_OPTS} Rcpp*.tar.gz
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_CHK_OPTS} ${PKG_TGZ}
 
 after_success:
   - docker run ${DOCKER_OPTS} -e CODECOV_TOKEN ${DOCKER_CNTR} r -l covr -e 'codecov()'


### PR DESCRIPTION
Minuscule change to .travis.yml I have been making in a few other repos where we use Docker to test.  Now derives package name and version from DESCRIPTION, which is cleaner.  And switched to bionic while we're at it.

Nothing else, no code or api or ... changes