### PR TITLE
Clang 9 Bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@
 
 2020-10-28  Dirk Eddelbuettel  <edd@debian.org>
 
-    * DESCRIPTION (Version, Date): Roll version and date
+        * DESCRIPTION (Version, Date): Roll version and date
 
 	* inst/tinytest/test_misc.R: Expand test coverage
 	* src/internal-utils.cpp: Mark one line #nocov

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
+2020-10-31  Brendan Knapp  <brendan.g.knapp@gmail.com>
+
+	* src/simdjson_example.cpp: Macro-guard two Rcout calls in parseExample()
+	against compiling on Clang 9
+
 2020-10-28  Dirk Eddelbuettel  <edd@debian.org>
 
-        * DESCRIPTION (Version, Date): Roll version and date
+    * DESCRIPTION (Version, Date): Roll version and date
 
 	* inst/tinytest/test_misc.R: Expand test coverage
 	* src/internal-utils.cpp: Mark one line #nocov

--- a/src/simdjson_example.cpp
+++ b/src/simdjson_example.cpp
@@ -51,10 +51,11 @@ void parseExample() {
 
   // Iterating through an array of objects
   for (simdjson::dom::object car : cars) {
+#if !defined(__clang__) || __clang_major__ != 9
     // Accessing a field by name
     Rcpp::Rcout << "Make/Model: " << car["make"]
                 << "/" << car["model"] << std::endl;
-
+#endif
     // Casting a JSON element to an integer
     uint64_t year = car["year"];
     Rcpp::Rcout << "- This car is " << 2020 - year
@@ -69,9 +70,11 @@ void parseExample() {
                 << (total_tire_pressure / 2) << std::endl;
 
     // Writing out all the information about the car
+#if !defined(__clang__) || __clang_major__ != 9
     for (auto [key, value] : car) {
       Rcpp::Rcout << "- " << key << ": " << value << std::endl;
     }
+#endif
   }
 }
 


### PR DESCRIPTION
Workaround verified over [here](https://github.com/knapply/rcppsimdgeojson/runs/1336429750?check_suite_focus=true).

For completeness sake, you can reproduce the fit thrown by the compiler when `CXX17 = clang++-9` with the following:


<details>
<summary>No issue w/ current CRAN</summary>

``` r
Makevars <- readLines("/home/brendan/.R/Makevars")
Makevars[grepl("^CXX17\\s{0,}=", Makevars)]
#> [1] "CXX17          = clang++-9"

install.packages("RcppSimdJson", version = "0.1.2") # current CRAN version
#> Installing package into '/home/brendan/R/x86_64-pc-linux-gnu-library/4.0'
#> (as 'lib' is unspecified)

RcppSimdJson::fparse('{"Good to go?": true}')
#> $`Good to go?`
#> [1] TRUE
```

</details>

<details>
  <summary>Clang 9 throws a fit when installing from current GitHub master</summary>

``` r
Makevars <- readLines("/home/brendan/.R/Makevars")
Makevars[grepl("^CXX17\\s{0,}=", Makevars)]
#> [1] "CXX17          = clang++-9"

remotes::install_github("eddelbuettel/rcppsimdjson@f3dd32b1adf536cf011adc1f63895a423abcde27") # current master
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo eddelbuettel/rcppsimdjson@f3dd32b1adf536cf011adc1f63895a423abcde27
#> 
#>      checking for file ‘/tmp/Rtmp0Qnsyc/remotes6a844056865/eddelbuettel-rcppsimdjson-f3dd32b/DESCRIPTION’ ...  ✓  checking for file ‘/tmp/Rtmp0Qnsyc/remotes6a844056865/eddelbuettel-rcppsimdjson-f3dd32b/DESCRIPTION’
#>   ─  preparing ‘RcppSimdJson’:
#>    checking DESCRIPTION meta-information ...  ✓  checking DESCRIPTION meta-information
#>   ─  cleaning src
#> ─  running ‘cleanup’
#>   ─  installing the package to process help pages
#>            -----------------------------------
#>   ─  installing *source* package ‘RcppSimdJson’ ...
#>    ** using staged installation
#>    ** setting up C++17
#>    ** libs
#>    clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c RcppExports.cpp -o RcppExports.o
#>    clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c deserialize.cpp -o deserialize.o
#>    clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c internal-utils.cpp -o internal-utils.o
#>    clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c rcppsimdjson_utils_check.cpp -o rcppsimdjson_utils_check.o
#>    clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c simdjson_example.cpp -o simdjson_example.o
#>    Stack dump:
#> 0.   Program arguments: /usr/lib/llvm-9/bin/clang -cc1 -triple x86_64-pc-linux-gnu -emit-obj -disable-free -disable-llvm-verifier -discard-value-names -main-file-name simdjson_example.cpp -mrelocation-model pic -pic-level 1 -mthread-model posix -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu skylake -target-feature +sse2 -target-feature +cx16 -target-feature +sahf -target-feature -tbm -target-feature -avx512ifma -target-feature -sha -target-feature -gfni -target-feature -fma4 -target-feature -vpclmulqdq -target-feature +prfchw -target-feature +bmi2 -target-feature   0.    Program arguments: /usr/lib/llvm-9/bin/clang -cc1 -triple x86_64-pc-linux-gnu -emit-obj -disable-free -disable-llvm-verifier -discard-value-names -main-file-name simdjson_example.cpp -mrelocation-model pic -pic-level 1 -mthread-model posix -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu skylake -target-feature +sse2 -target-feature +cx16 -target-feature +sahf -target-feature -tbm -target-feature -avx512ifma -target-feature -sha -target-feature -gfni -target-feature -fma4 -target-feature -vpclmulqdq -target-feature +prfchw -target-feature +bmi2 -target-feature -cldemote -target-feature +fsgsbase -target-feature -ptwrite -target-feature +xsavec -target-feature +popcnt -target-feature +mpx -target-feature +aes -target-feature -avx512bitalg -target-feature -movdiri -target-feature +xsaves -target-feature -avx512er -target-feature -avx512vnni -target-feature -avx512vpopcntdq -target-feature -pconfig -target-feature -clwb -target-feature -avx512f -target-feature -clzero -target-feature -pku -target-feature +mmx -target-feature -lwp -target-feature -rdpid -target-feature -xop -target-feature +rdseed -target-feature -waitpkg -target-feature -movdir64b -target-feature -sse4a -target-feature -avx512bw -target-feature +clflushopt -target-feature +xsave -target-feature -avx512vbmi2 -target-feature +64bit -target-feature -avx512vl -target-feature +invpcid -target-feature -avx512cd -target-feature +avx -target-feature -vaes -target-feature +cx8 -target-feature +fma -target-feature -rtm -target-feature +bmi -target-feature -enqcmd -target-feature +rdrnd -target-feature -mwaitx -target-feature +sse4.1 -target-feature +sse4.2 -target-feature +avx2 -target-feature +fxsr -target-feature -wbnoinvd -target-feature +sse -target-feature +lzcnt -target-feature +pclmul -target-feature -prefetchwt1 -target-feature +f16c -target-feature +ssse3 -target-feature +sgx -target-feature -shstk -target-feature +cmov -target-feature -avx512vbmi -target-feature -avx512bf16 -target-feature +movbe -target-feature +xsaveopt -target-feature -avx512dq -target-feature +adx -target-feature -avx512pf -target-feature +sse3 -dwarf-column-info -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -momit-leaf-frame-pointer -coverage-notes-file /tmp/RtmprltmKG/Rbuild6ade72e4a926/RcppSimdJson/src/simdjson_example.gcno -resource-dir /usr/lib/llvm-9/lib/clang/9.0.0 -I /usr/share/R/include -D NDEBUG -I /home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include -D SIMDJSON_NO_COMPUTED_GOTO -I ../inst/include -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/1     0. Program arguments: /usr/lib/llvm-9/bin/clang -cc1 -triple x86_64-pc-linux-gnu -emit-obj -disable-free -disable-llvm-verifier -discard-value-names -main-file-name simdjson_example.cpp -mrelocation-model pic -pic-level 1 -mthread-model posix -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu skylake -target-feature +sse2 -target-feature +cx16 -target-feature +sahf -target-feature -tbm -target-feature -avx512ifma -target-feature -sha -target-feature -gfni -target-feature -fma4 -target-feature -vpclmulqdq -target-feature +prfchw -target-feature +bmi2 -target-feature -cldemote -target-feature +fsgsbase -target-feature -ptwrite -target-feature +xsavec -target-feature +popcnt -target-feature +mpx -target-feature +aes -target-feature -avx512bitalg -target-feature -movdiri -target-feature +xsaves -target-feature -avx512er -target-feature -avx512vnni -target-feature -avx512vpopcntdq -target-feature -pconfig -target-feature -clwb -target-feature -avx512f -target-feature -clzero -target-feature -pku -target-feature +mmx -target-feature -lwp -target-feature -rdpid -target-feature -xop -target-feature +rdseed -target-feature -waitpkg -target-feature -movdir64b -target-feature -sse4a -target-feature -avx512bw -target-feature +clflushopt -target-feature +xsave -target-feature -avx512vbmi2 -target-feature +64bit -target-feature -avx512vl -target-feature +invpcid -target-feature -avx512cd -target-feature +avx -target-feature -vaes -target-feature +cx8 -target-feature +fma -target-feature -rtm -target-feature +bmi -target-feature -enqcmd -target-feature +rdrnd -target-feature -mwaitx -target-feature +sse4.1 -target-feature +sse4.2 -target-feature +avx2 -target-feature +fxsr -target-feature -wbnoinvd -target-feature +sse -target-feature +lzcnt -target-feature +pclmul -target-feature -prefetchwt1 -target-feature +f16c -target-feature +ssse3 -target-feature +sgx -target-feature -shstk -target-feature +cmov -target-feature -avx512vbmi -target-feature -avx512bf16 -target-feature +movbe -target-feature +xsaveopt -target-feature -avx512dq -target-feature +adx -target-feature -avx512pf -target-feature +sse3 -dwarf-column-info -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -momit-leaf-frame-pointer -coverage-notes-file /tmp/RtmprltmKG/Rbuild6ade72e4a926/RcppSimdJson/src/simdjson_example.gcno -resource-dir /usr/lib/llvm-9/lib/clang/9.0.0 -I /usr/share/R/include -D NDEBUG -I /home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include -D SIMDJSON_NO_COMPUTED_GOTO -I ../inst/include -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/backward -internal-isystem /usr/local/include -internal-isystem /usr/lib/llvm-9/lib/clang/9.0.0/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -O3 -std=gnu++17 -fdeprecated-macro -fdebug-compilation-dir /tmp/RtmprltmKG/Rbuild6ade72e4a926/RcppSimdJson/src -ferror-limit 19 -fmessage-length 0 -fopenmp -fobjc-runtime=gcc -fcxx-exceptions -fexceptions -fdiagnostics-show-option -vectorize-loops -vectorize-slp -faddrsig -o simdjson_example.o -x c++ simdjson_example.cpp 
#>    1.    <eof> parser at end of file
#>    2.    Per-file LLVM IR generation
#>    3.    ../inst/include/simdjson.h:8254:45: Generating code for declaration 'simdjson::internal::mini_formatter::string'
#>    4.    ../inst/include/simdjson.h:8269:45: LLVM IR generation of compound statement ('{}')
#>     #0 0x00007f5ba219835f llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa3835f)
#>     #1 0x00007f5ba2196780 llvm::sys::RunSignalHandlers() (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa36780)
#>     #2 0x00007f5ba2198761 (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa38761)
#>     #3 0x00007f5ba7e1d8a0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x128a0)
#>     #4 0x00007f5ba22d59a2 llvm::PointerType::get(llvm::Type*, unsigned int) (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xb759a2)
#>     #5 0x00007f5ba6bb9afa getType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Value.h:244:34
#>     #6 0x00007f5ba6bb9afa getGEPReturnType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:1046:14
#>   #7 0x00007f5ba6bb9a4c GetElementPtrInst /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/I      #7 0x00007f5ba6bb9a4c GetElementPtrInst /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:1113:66
#>     #8 0x00007f5ba6bb9a4c Create /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:913:25
#>     #9 0x00007f5ba6c3903a CreateInBounds /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:947:9
#>    #10 0x00007f5ba6c3903a CreateInBoundsGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/IRBuilder.h:1713:19
#>    #11 0x00007f5ba6cbbafc CreateInBoundsGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/IRBuilder.h:1698:12
#>    #12 0x00007f5ba6cbbafc clang::CodeGen::CodeGenFunction::EmitCheckedInBoundsGEP(llvm::Value*, llvm::ArrayRef<llvm::Value*>, bool, bool, clang::SourceLocation, llvm::Twine const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:4542:27
#>    #13 0x00007f5ba6c8b47b emitArraySubscriptGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3367:16
#>    #14 0x00007f5ba6c8b47b emitArraySubscriptGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3425:14
#>    #15 0x00007f5ba6c7e4c5 clang::CodeGen::CodeGenFunction::EmitArraySubscriptExpr(clang::ArraySubscriptExpr const*, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3570:12
#>    #16 0x00007f5ba6c75b46 clang::CodeGen::CodeGenFunction::EmitLValue(clang::Expr const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:1341:12
#>    #17 0x00007f5ba6c7cf7a clang::CodeGen::CodeGenFunction::EmitCheckedLValue(clang::Expr const*, clang::CodeGen::CodeGenFunction::TypeCheckKind) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:0:0
#>    #18 0x00007f5ba6cbc9da Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:0:0
#>    #19 0x00007f5ba6cc6c1b VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:0:0
#> #20 0x00007f5ba6cc7a0b Visit /build/llvm-to     #20 0x00007f5ba6cc7a0b Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #21 0x00007f5ba6cc7a0b VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2232:33
#>    #22 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #23 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #24 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #25 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #26 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #27 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #28 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #29 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #30 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #31 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #32 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #33 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #34 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> #35 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/cla     #35 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #36 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #37 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #38 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #39 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #40 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #41 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #42 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #43 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #44 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #45 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #46 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #47 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#>    #48 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#>    #49 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#>    #50 0x00007f5ba6cc7640 Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> #51 0x00007f5     #51 0x00007f5ba6cc7640 VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2247:36
#>    #52 0x00007f5ba6cb530f Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#>    #53 0x00007f5ba6cb530f clang::CodeGen::CodeGenFunction::EmitScalarExpr(clang::Expr const*, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:4436:8
#>    #54 0x00007f5ba6c75411 getType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/Expr.h:137:37
#>    #55 0x00007f5ba6c75411 clang::CodeGen::CodeGenFunction::EvaluateExprAsBool(clang::Expr const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:174:55
#>    #56 0x00007f5ba6dde367 clang::CodeGen::CodeGenFunction::EmitBranchOnBoolExpr(clang::Expr const*, llvm::BasicBlock*, llvm::BasicBlock*, unsigned long) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1547:13
#>    #57 0x00007f5ba6d99de2 clang::CodeGen::CodeGenFunction::EmitIfStmt(clang::IfStmt const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:668:3
#>    #58 0x00007f5ba6d99277 clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:139:32
#>    #59 0x00007f5ba6da23fc clang::CodeGen::CodeGenFunction::EmitCompoundStmtWithoutScope(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:390:22
#>    #60 0x00007f5ba6da1998 clang::CodeGen::CodeGenFunction::EmitCompoundStmt(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:376:10
#> #61 0x00007f5ba6d996e6 clang::CodeGen::CodeGenFunction::EmitSimpleStmt(clang::Stmt const*) /build/llvm-toolchain-9-uSl4bC/llvm-t     #61 0x00007f5ba6d996e6 clang::CodeGen::CodeGenFunction::EmitSimpleStmt(clang::Stmt const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:349:33
#>    #62 0x00007f5ba6d9903b clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:49:7
#>    #63 0x00007f5ba6d9b6b2 ForceCleanup /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:755:28
#>    #64 0x00007f5ba6d9b6b2 ~RunCleanupsScope /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:739:9
#>    #65 0x00007f5ba6d9b6b2 clang::CodeGen::CodeGenFunction::EmitForStmt(clang::ForStmt const&, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:923:3
#>    #66 0x00007f5ba6d99267 clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:142:32
#>    #67 0x00007f5ba6da23fc clang::CodeGen::CodeGenFunction::EmitCompoundStmtWithoutScope(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:390:22
#>    #68 0x00007f5ba6ddcee2 clang::CodeGen::CodeGenFunction::EmitFunctionBody(clang::Stmt const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1036:1
#>    #69 0x00007f5ba6ddd70f getLangOpts /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:1630:51
#>    #70 0x00007f5ba6ddd70f clang::CodeGen::CodeGenFunction::GenerateCode(clang::GlobalDecl, llvm::Function*, clang::CodeGen::CGFunctionInfo const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1208:7
#> #71 0x00007f5ba6df4b8e clang::CodeGen::CodeGenModule::EmitGlobalFunctionDefinition(clang::GlobalDecl, llvm::GlobalValue*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:     #71 0x00007f5ba6df4b8e clang::CodeGen::CodeGenModule::EmitGlobalFunctionDefinition(clang::GlobalDecl, llvm::GlobalValue*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:4320:3
#>    #72 0x00007f5ba6def19d isVirtual /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/DeclCXX.h:2158:59
#>    #73 0x00007f5ba6def19d clang::CodeGen::CodeGenModule::EmitGlobalDefinition(clang::GlobalDecl, llvm::GlobalValue*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2751:19
#>    #74 0x00007f5ba6de5da3 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:573:45
#>    #75 0x00007f5ba6de5da3 empty /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:760:16
#>    #76 0x00007f5ba6de5da3 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2123:26
#>    #77 0x00007f5ba6de5d38 operator++ /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:805:2
#>    #78 0x00007f5ba6de5d38 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2091:22
#>    #79 0x00007f5ba6de5d38 operator++ /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:805:2
#>    #80 0x00007f5ba6de5d38 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2091:22
#>    #81 0x00007f5ba6de51d7 __normal_iterator /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:783:20
#>    #82 0x00007f5ba6de51d7 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:564:16
#>    #83 0x00007f5ba6de51d7 EmitVTablesOpportunistically /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2139:32
#>    #84 0x00007f5ba6de51d7 clang::CodeGen::CodeGenModule::Release() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:394:3
#> #85 0x00007f5ba6e5f264 HandleTranslationUnit /build/llvm-toolchain-9-uSl4bC/llvm-     #85 0x00007f5ba6e5f264 HandleTranslationUnit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/ModuleBuilder.cpp:260:11
#>    #86 0x00007f5ba6dd5bb6 HandleTranslationUnit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenAction.cpp:240:13
#>    #87 0x00007f5ba6105a03 __normal_iterator /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:783:20
#>    #88 0x00007f5ba6105a03 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:564:16
#>    #89 0x00007f5ba6105a03 finalize<std::vector<std::unique_ptr<clang::TemplateInstantiationCallback, std::default_delete<clang::TemplateInstantiationCallback> >, std::allocator<std::unique_ptr<clang::TemplateInstantiationCallback, std::default_delete<clang::TemplateInstantiationCallback> > > > > /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/Sema/TemplateInstCallback.h:54:16
#>    #90 0x00007f5ba6105a03 clang::ParseAST(clang::Sema&, bool, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Parse/ParseAST.cpp:178:3
#>    #91 0x00007f5ba73a74c8 clang::FrontendAction::Execute() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Frontend/FrontendAction.cpp:938:10
#>    #92 0x00007f5ba7366ce0 getPtr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/Support/Error.h:273:42
#>    #93 0x00007f5ba7366ce0 operator bool /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/Support/Error.h:236:16
#>    #94 0x00007f5ba7366ce0 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Frontend/CompilerInstance.cpp:944:23
#>    #95 0x00007f5ba740a210 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:291:25
#>    #96 0x0000000000498a5b cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/lib/llvm-9/bin/clang+0x498a5b)
#>    #97 0x0000000000496d71 main (/usr/lib/llvm-9/bin/clang+0x496d71)
#> #98 0x00007f5     #98 0x00007f5ba0a06b97 __libc_start_main /build/glibc-2ORdQG/glibc-2.27/csu/../csu/libc-start.c:344:0
#>    #99 0x00000000004941ea _start (/usr/lib/llvm-9/bin/clang+0x4941ea)
#>    clang: error: unable to execute command: Segmentation fault (core dumped)
#>    clang: error: clang frontend command failed due to signal (use -v to see invocation)
#>    clang version 9.0.0-2~ubuntu18.04.2 (tags/RELEASE_900/final)
#>    Target: x86_64-pc-linux-gnu
#>    Thread model: posix
#>    InstalledDir: /usr/bin
#>    clang: note: diagnostic msg: PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
#>    clang: note: diagnostic msg: 
#>    ********************
#>    
#>    PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
#>    Preprocessed source(s) and associated run script(s) are located at:
#>    clang: note: diagnostic msg: /tmp/simdjson_example-a1e5da.cpp
#>    clang: note: diagnostic msg: /tmp/simdjson_example-a1e5da.sh
#>    clang: note: diagnostic msg: 
#>    
#>    ********************
#>    /usr/lib/R/etc/Makeconf:176: recipe for target 'simdjson_example.o' failed
#>    make: *** [simdjson_example.o] Error 254
#>    ERROR: compilation failed for package ‘RcppSimdJson’
#> ─  removing ‘/tmp/RtmprltmKG/Rinst6adea179921/RcppSimdJson’
#>          -----------------------------------
#>    ERROR: package installation failed
#> 
#> Error: Failed to install 'RcppSimdJson' from GitHub:
#>   System command 'R' failed, exit status: 1, stdout + stderr:
#> E> * checking for file ‘/tmp/Rtmp0Qnsyc/remotes6a844056865/eddelbuettel-rcppsimdjson-f3dd32b/DESCRIPTION’ ... OK
#> E> * preparing ‘RcppSimdJson’:
#> E> * checking DESCRIPTION meta-information ... OK
#> E> * cleaning src
#> E> * running ‘cleanup’
#> E> * installing the package to process help pages
#> E>       -----------------------------------
#> E> * installing *source* package ‘RcppSimdJson’ ...
#> E> ** using staged installation
#> E> ** setting up C++17
#> E> ** libs
#> E> clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c RcppExports.cpp -o RcppExports.o
#> E> clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c deserialize.cpp -o deserialize.o
#> E> clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c internal-utils.cpp -o internal-utils.o
#> E> clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c rcppsimdjson_utils_check.cpp -o rcppsimdjson_utils_check.o
#> E> clang++-9 -std=gnu++17 -I"/usr/share/R/include" -DNDEBUG  -I'/home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include'   -DSIMDJSON_NO_COMPUTED_GOTO -I../inst/include -fopenmp -fpic  -g -O3 -march=native  -c simdjson_example.cpp -o simdjson_example.o
#> E> Stack dump:
#> E> 0.    Program arguments: /usr/lib/llvm-9/bin/clang -cc1 -triple x86_64-pc-linux-gnu -emit-obj -disable-free -disable-llvm-verifier -discard-value-names -main-file-name simdjson_example.cpp -mrelocation-model pic -pic-level 1 -mthread-model posix -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu skylake -target-feature +sse2 -target-feature +cx16 -target-feature +sahf -target-feature -tbm -target-feature -avx512ifma -target-feature -sha -target-feature -gfni -target-feature -fma4 -target-feature -vpclmulqdq -target-feature +prfchw -target-feature +bmi2 -target-feature -cldemote -target-feature +fsgsbase -target-feature -ptwrite -target-feature +xsavec -target-feature +popcnt -target-feature +mpx -target-feature +aes -target-feature -avx512bitalg -target-feature -movdiri -target-feature +xsaves -target-feature -avx512er -target-feature -avx512vnni -target-feature -avx512vpopcntdq -target-feature -pconfig -target-feature -clwb -target-feature -avx512f -target-feature -clzero -target-feature -pku -target-feature +mmx -target-feature -lwp -target-feature -rdpid -target-feature -xop -target-feature +rdseed -target-feature -waitpkg -target-feature -movdir64b -target-feature -sse4a -target-feature -avx512bw -target-feature +clflushopt -target-feature +xsave -target-feature -avx512vbmi2 -target-feature +64bit -target-feature -avx512vl -target-feature +invpcid -target-feature -avx512cd -target-feature +avx -target-feature -vaes -target-feature +cx8 -target-feature +fma -target-feature -rtm -target-feature +bmi -target-feature -enqcmd -target-feature +rdrnd -target-feature -mwaitx -target-feature +sse4.1 -target-feature +sse4.2 -target-feature +avx2 -target-feature +fxsr -target-feature -wbnoinvd -target-feature +sse -target-feature +lzcnt -target-feature +pclmul -target-feature -prefetchwt1 -target-feature +f16c -target-feature +ssse3 -target-feature +sgx -target-feature -shstk -target-feature +cmov -target-feature -avx512vbmi -target-feature -avx512bf16 -target-feature +movbe -target-feature +xsaveopt -target-feature -avx512dq -target-feature +adx -target-feature -avx512pf -target-feature +sse3 -dwarf-column-info -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -momit-leaf-frame-pointer -coverage-notes-file /tmp/RtmprltmKG/Rbuild6ade72e4a926/RcppSimdJson/src/simdjson_example.gcno -resource-dir /usr/lib/llvm-9/lib/clang/9.0.0 -I /usr/share/R/include -D NDEBUG -I /home/brendan/R/x86_64-pc-linux-gnu-library/4.0/Rcpp/include -D SIMDJSON_NO_COMPUTED_GOTO -I ../inst/include -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/backward -internal-isystem /usr/local/include -internal-isystem /usr/lib/llvm-9/lib/clang/9.0.0/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -O3 -std=gnu++17 -fdeprecated-macro -fdebug-compilation-dir /tmp/RtmprltmKG/Rbuild6ade72e4a926/RcppSimdJson/src -ferror-limit 19 -fmessage-length 0 -fopenmp -fobjc-runtime=gcc -fcxx-exceptions -fexceptions -fdiagnostics-show-option -vectorize-loops -vectorize-slp -faddrsig -o simdjson_example.o -x c++ simdjson_example.cpp 
#> E> 1.    <eof> parser at end of file
#> E> 2.    Per-file LLVM IR generation
#> E> 3.    ../inst/include/simdjson.h:8254:45: Generating code for declaration 'simdjson::internal::mini_formatter::string'
#> E> 4.    ../inst/include/simdjson.h:8269:45: LLVM IR generation of compound statement ('{}')
#> E>  #0 0x00007f5ba219835f llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa3835f)
#> E>  #1 0x00007f5ba2196780 llvm::sys::RunSignalHandlers() (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa36780)
#> E>  #2 0x00007f5ba2198761 (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xa38761)
#> E>  #3 0x00007f5ba7e1d8a0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x128a0)
#> E>  #4 0x00007f5ba22d59a2 llvm::PointerType::get(llvm::Type*, unsigned int) (/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1+0xb759a2)
#> E>  #5 0x00007f5ba6bb9afa getType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Value.h:244:34
#> E>  #6 0x00007f5ba6bb9afa getGEPReturnType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:1046:14
#> E>  #7 0x00007f5ba6bb9a4c GetElementPtrInst /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:1113:66
#> E>  #8 0x00007f5ba6bb9a4c Create /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:913:25
#> E>  #9 0x00007f5ba6c3903a CreateInBounds /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/Instructions.h:947:9
#> E> #10 0x00007f5ba6c3903a CreateInBoundsGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/IRBuilder.h:1713:19
#> E> #11 0x00007f5ba6cbbafc CreateInBoundsGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/IR/IRBuilder.h:1698:12
#> E> #12 0x00007f5ba6cbbafc clang::CodeGen::CodeGenFunction::EmitCheckedInBoundsGEP(llvm::Value*, llvm::ArrayRef<llvm::Value*>, bool, bool, clang::SourceLocation, llvm::Twine const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:4542:27
#> E> #13 0x00007f5ba6c8b47b emitArraySubscriptGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3367:16
#> E> #14 0x00007f5ba6c8b47b emitArraySubscriptGEP /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3425:14
#> E> #15 0x00007f5ba6c7e4c5 clang::CodeGen::CodeGenFunction::EmitArraySubscriptExpr(clang::ArraySubscriptExpr const*, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:3570:12
#> E> #16 0x00007f5ba6c75b46 clang::CodeGen::CodeGenFunction::EmitLValue(clang::Expr const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:1341:12
#> E> #17 0x00007f5ba6c7cf7a clang::CodeGen::CodeGenFunction::EmitCheckedLValue(clang::Expr const*, clang::CodeGen::CodeGenFunction::TypeCheckKind) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:0:0
#> E> #18 0x00007f5ba6cbc9da Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:0:0
#> E> #19 0x00007f5ba6cc6c1b VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:0:0
#> E> #20 0x00007f5ba6cc7a0b Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #21 0x00007f5ba6cc7a0b VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2232:33
#> E> #22 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #23 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #24 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #25 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #26 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #27 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #28 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #29 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #30 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #31 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #32 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #33 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #34 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #35 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #36 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #37 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #38 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #39 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #40 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #41 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #42 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #43 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #44 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #45 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #46 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #47 0x00007f5ba6cbd3ac EmitBinOps /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2806:16
#> E> #48 0x00007f5ba6cbd3ac VisitBinOr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:789:3
#> E> #49 0x00007f5ba6cbd3ac Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/StmtVisitor.h:68:26
#> E> #50 0x00007f5ba6cc7640 Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #51 0x00007f5ba6cc7640 VisitCastExpr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:2247:36
#> E> #52 0x00007f5ba6cb530f Visit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:424:52
#> E> #53 0x00007f5ba6cb530f clang::CodeGen::CodeGenFunction::EmitScalarExpr(clang::Expr const*, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExprScalar.cpp:4436:8
#> E> #54 0x00007f5ba6c75411 getType /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/Expr.h:137:37
#> E> #55 0x00007f5ba6c75411 clang::CodeGen::CodeGenFunction::EvaluateExprAsBool(clang::Expr const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGExpr.cpp:174:55
#> E> #56 0x00007f5ba6dde367 clang::CodeGen::CodeGenFunction::EmitBranchOnBoolExpr(clang::Expr const*, llvm::BasicBlock*, llvm::BasicBlock*, unsigned long) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1547:13
#> E> #57 0x00007f5ba6d99de2 clang::CodeGen::CodeGenFunction::EmitIfStmt(clang::IfStmt const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:668:3
#> E> #58 0x00007f5ba6d99277 clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:139:32
#> E> #59 0x00007f5ba6da23fc clang::CodeGen::CodeGenFunction::EmitCompoundStmtWithoutScope(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:390:22
#> E> #60 0x00007f5ba6da1998 clang::CodeGen::CodeGenFunction::EmitCompoundStmt(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:376:10
#> E> #61 0x00007f5ba6d996e6 clang::CodeGen::CodeGenFunction::EmitSimpleStmt(clang::Stmt const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:349:33
#> E> #62 0x00007f5ba6d9903b clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:49:7
#> E> #63 0x00007f5ba6d9b6b2 ForceCleanup /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:755:28
#> E> #64 0x00007f5ba6d9b6b2 ~RunCleanupsScope /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:739:9
#> E> #65 0x00007f5ba6d9b6b2 clang::CodeGen::CodeGenFunction::EmitForStmt(clang::ForStmt const&, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:923:3
#> E> #66 0x00007f5ba6d99267 clang::CodeGen::CodeGenFunction::EmitStmt(clang::Stmt const*, llvm::ArrayRef<clang::Attr const*>) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:142:32
#> E> #67 0x00007f5ba6da23fc clang::CodeGen::CodeGenFunction::EmitCompoundStmtWithoutScope(clang::CompoundStmt const&, bool, clang::CodeGen::AggValueSlot) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CGStmt.cpp:390:22
#> E> #68 0x00007f5ba6ddcee2 clang::CodeGen::CodeGenFunction::EmitFunctionBody(clang::Stmt const*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1036:1
#> E> #69 0x00007f5ba6ddd70f getLangOpts /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.h:1630:51
#> E> #70 0x00007f5ba6ddd70f clang::CodeGen::CodeGenFunction::GenerateCode(clang::GlobalDecl, llvm::Function*, clang::CodeGen::CGFunctionInfo const&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenFunction.cpp:1208:7
#> E> #71 0x00007f5ba6df4b8e clang::CodeGen::CodeGenModule::EmitGlobalFunctionDefinition(clang::GlobalDecl, llvm::GlobalValue*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:4320:3
#> E> #72 0x00007f5ba6def19d isVirtual /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/AST/DeclCXX.h:2158:59
#> E> #73 0x00007f5ba6def19d clang::CodeGen::CodeGenModule::EmitGlobalDefinition(clang::GlobalDecl, llvm::GlobalValue*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2751:19
#> E> #74 0x00007f5ba6de5da3 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:573:45
#> E> #75 0x00007f5ba6de5da3 empty /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:760:16
#> E> #76 0x00007f5ba6de5da3 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2123:26
#> E> #77 0x00007f5ba6de5d38 operator++ /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:805:2
#> E> #78 0x00007f5ba6de5d38 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2091:22
#> E> #79 0x00007f5ba6de5d38 operator++ /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:805:2
#> E> #80 0x00007f5ba6de5d38 clang::CodeGen::CodeGenModule::EmitDeferred() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2091:22
#> E> #81 0x00007f5ba6de51d7 __normal_iterator /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:783:20
#> E> #82 0x00007f5ba6de51d7 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:564:16
#> E> #83 0x00007f5ba6de51d7 EmitVTablesOpportunistically /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:2139:32
#> E> #84 0x00007f5ba6de51d7 clang::CodeGen::CodeGenModule::Release() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenModule.cpp:394:3
#> E> #85 0x00007f5ba6e5f264 HandleTranslationUnit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/ModuleBuilder.cpp:260:11
#> E> #86 0x00007f5ba6dd5bb6 HandleTranslationUnit /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/CodeGen/CodeGenAction.cpp:240:13
#> E> #87 0x00007f5ba6105a03 __normal_iterator /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_iterator.h:783:20
#> E> #88 0x00007f5ba6105a03 begin /usr/lib/gcc/x86_64-linux-gnu/7.4.0/../../../../include/c++/7.4.0/bits/stl_vector.h:564:16
#> E> #89 0x00007f5ba6105a03 finalize<std::vector<std::unique_ptr<clang::TemplateInstantiationCallback, std::default_delete<clang::TemplateInstantiationCallback> >, std::allocator<std::unique_ptr<clang::TemplateInstantiationCallback, std::default_delete<clang::TemplateInstantiationCallback> > > > > /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/include/clang/Sema/TemplateInstCallback.h:54:16
#> E> #90 0x00007f5ba6105a03 clang::ParseAST(clang::Sema&, bool, bool) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Parse/ParseAST.cpp:178:3
#> E> #91 0x00007f5ba73a74c8 clang::FrontendAction::Execute() /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Frontend/FrontendAction.cpp:938:10
#> E> #92 0x00007f5ba7366ce0 getPtr /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/Support/Error.h:273:42
#> E> #93 0x00007f5ba7366ce0 operator bool /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/include/llvm/Support/Error.h:236:16
#> E> #94 0x00007f5ba7366ce0 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/Frontend/CompilerInstance.cpp:944:23
#> E> #95 0x00007f5ba740a210 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) /build/llvm-toolchain-9-uSl4bC/llvm-toolchain-9-9/tools/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:291:25
#> E> #96 0x0000000000498a5b cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/lib/llvm-9/bin/clang+0x498a5b)
#> E> #97 0x0000000000496d71 main (/usr/lib/llvm-9/bin/clang+0x496d71)
#> E> #98 0x00007f5ba0a06b97 __libc_start_main /build/glibc-2ORdQG/glibc-2.27/csu/../csu/libc-start.c:344:0
#> E> #99 0x00000000004941ea _start (/usr/lib/llvm-9/bin/clang+0x4941ea)
#> E> clang: error: unable to execute command: Segmentation fault (core dumped)
#> E> clang: error: clang frontend command failed due to signal (use -v to see invocation)
#> E> clang version 9.0.0-2~ubuntu18.04.2 (tags/RELEASE_900/final)
#> E> Target: x86_64-pc-linux-gnu
#> E> Thread model: posix
#> E> InstalledDir: /usr/bin
#> E> clang: note: diagnostic msg: PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
#> E> clang: note: diagnostic msg: 
#> E> ********************
#> E> 
#> E> PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
#> E> Preprocessed source(s) and associated run script(s) are located at:
#> E> clang: note: diagnostic msg: /tmp/simdjson_example-a1e5da.cpp
#> E> clang: note: diagnostic msg: /tmp/simdjson_example-a1e5da.sh
#> E> clang: note: diagnostic msg: 
#> E> 
#> E> ********************
#> E> /usr/lib/R/etc/Makeconf:176: recipe for target 'simdjson_example.o' failed
#> E> make: *** [simdjson_example.o] Error 254
#> E> ERROR: compilation failed for package ‘RcppSimdJson’
#> E> * removing ‘/tmp/RtmprltmKG/Rinst6adea179921/RcppSimdJson’
#> E>       -----------------------------------
#> E> ERROR: package installation failed
```

</details>


@lemire, in case you're wondering what this is about, I haven't been able to reproduce the problem with only C++ (with any clang version, or any C++ standard>=11) so I suspect it's an R-specific issue.

