### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,27 +11,24 @@ env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - name: gcc-7
-            cxx11: g++-7
-            cxx17: g++-7
+            cxx: g++-7
             cc: gcc-7
           - name: gcc-8
-            cxx11: g++-8
-            cxx17: g++-8
+            cxx: g++-8
             cc: gcc-8
           - name: gcc-9
-            cxx11: g++-9
-            cxx17: g++-9
+            cxx: g++-9
             cc: gcc-9
           - name: gcc-10
-            cxx11: g++-10
-            cxx17: g++-10
+            cxx: g++-10
             cc: gcc-10
+            coverage: true
 
     steps:
       - uses: actions/checkout@v2
@@ -44,8 +41,8 @@ jobs:
 
       - name: Compiler
         run: |
-          ./run.sh install_aptget ${{ matrix.cxx17 }}
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.cc }} 60 --slave /usr/bin/g++ g++ /usr/bin/${{matrix.cxx17 }}
+          ./run.sh install_aptget ${{ matrix.cxx }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.cc }} 60 --slave /usr/bin/g++ g++ /usr/bin/${{matrix.cxx }}
           g++ --version
         
       - name: Dependencies
@@ -55,5 +52,6 @@ jobs:
         run: ./run.sh run_tests
 
       - name: Coverage
+        if: ${{ matrix.coverage }}
         run: ./run.sh coverage
         

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,59 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  USE_BSPM: "true"
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: gcc-7
+            cxx11: g++-7
+            cxx17: g++-7
+            cc: gcc-7
+          - name: gcc-8
+            cxx11: g++-8
+            cxx17: g++-8
+            cc: gcc-8
+          - name: gcc-9
+            cxx11: g++-9
+            cxx17: g++-9
+            cc: gcc-9
+          - name: gcc-10
+            cxx11: g++-10
+            cxx17: g++-10
+            cc: gcc-10
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bootstrap
+        run: |
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+
+      - name: Compiler
+        run: |
+          ./run.sh install_aptget ${{ matrix.cxx17 }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.cc }} 60 --slave /usr/bin/g++ g++ /usr/bin/${{matrix.cxx17 }}
+          g++ --version
+        
+      - name: Dependencies
+        run: ./run.sh install_all
+
+      - name: Test
+        run: ./run.sh run_tests
+
+      - name: Coverage
+        run: ./run.sh coverage
+        


### PR DESCRIPTION
Travis CI keeps talking about unlimited use for open source projects yet my runs are currently stalled -- not nice.

So this simple PR turns on GitHub Action with a build matrix just like the one we had before. 

No code, documentation or other changes.